### PR TITLE
Fix unescaped ampersands in HTML titles

### DIFF
--- a/site/accessibility.html
+++ b/site/accessibility.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Accessibility & Universal Design</title>
+    <title>Accessibility &amp; Universal Design</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/site/community.html
+++ b/site/community.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Community & Collaboration</title>
+    <title>Community &amp; Collaboration</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/site/index.html
+++ b/site/index.html
@@ -34,7 +34,7 @@
     <option data-href="ethics.html" value="Ethical Principles"></option>
     <option data-href="accessibility.html" value="Accessibility"></option>
     <option data-href="case-studies.html" value="Case Studies"></option>
-    <option data-href="policy.html" value="Policy & Legal"></option>
+    <option data-href="policy.html" value="Policy &amp; Legal"></option>
     <option data-href="technical.html" value="Technical Guidance"></option>
     <option data-href="community.html" value="Community"></option>
     <option data-href="ethical-ai-documentation.html" value="AI Documentation"></option>

--- a/site/intro.html
+++ b/site/intro.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Introduction to VR & AI</title>
+    <title>Introduction to VR &amp; AI</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/site/policy.html
+++ b/site/policy.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Policy, Legal & Compliance</title>
+    <title>Policy, Legal &amp; Compliance</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- fix HTML `&` encoding in page titles
- update search option value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420400a814832aa1dc90a2c0b42393