### PR TITLE
Revamp styling with flat borders

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,14 +1,14 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     margin: 0;
     padding: 0;
     line-height: 1.6;
-    background: linear-gradient(135deg, #0a0027, #001024);
+    background: linear-gradient(180deg, #000, #111);
     color: #e0e8ff;
 }
 
 body.home {
-    background: linear-gradient(135deg, #0a0027, #001024);
+    background: linear-gradient(180deg, #000, #111);
 }
 
 /* Skip link styles for improved keyboard navigation */
@@ -29,7 +29,7 @@ body.home {
     background: #fff;
     color: #000;
     padding: 0.5em 1em;
-    border: 2px solid #0ff;
+    border: 1px solid #333;
     z-index: 1000;
 }
 
@@ -38,9 +38,9 @@ header {
     color: #fff;
     padding: 1em 0;
     text-align: center;
-    border: 2px solid #0ff;
+    border: 1px solid #333;
     box-shadow: 0 0 15px rgba(0, 255, 255, 0.4);
-    border-radius: 0.5em;
+    border-radius: 0;
 }
 .logo {
     height: 50px;
@@ -51,9 +51,9 @@ nav {
     background-color: #000;
     padding: 0.5em 1em;
     text-align: center;
-    border: 2px solid #0ff;
+    border: 1px solid #333;
     box-shadow: 0 0 10px rgba(0, 255, 255, 0.3);
-    border-radius: 0.5em;
+    border-radius: 0;
 }
 
 nav a {
@@ -67,7 +67,7 @@ nav a {
 
 nav a:hover,
 nav a:focus {
-    border-color: #0ff;
+    border-color: #1d9bf0;
     outline: none;
 }
 
@@ -78,9 +78,9 @@ a:focus {
 
 main {
     padding: 1em;
-    border: 2px solid #0ff;
+    border: 1px solid #333;
     box-shadow: 0 0 15px rgba(0, 255, 255, 0.3);
-    border-radius: 0.5em;
+    border-radius: 0;
 }
 
 .hero {
@@ -88,9 +88,9 @@ main {
     background-image: linear-gradient(135deg, #0a0027, #001024);
     padding: 2em 1em;
     text-align: center;
-    border: 2px solid #0ff;
+    border: 1px solid #333;
     box-shadow: 0 0 20px rgba(0, 255, 255, 0.4);
-    border-radius: 0.5em;
+    border-radius: 0;
 }
 
 .hero h2 {
@@ -107,9 +107,9 @@ main {
 .intro-text {
     max-width: 800px;
     margin: 1em auto;
-    border: 2px solid #0ff;
+    border: 1px solid #333;
     box-shadow: 0 0 15px rgba(0, 255, 255, 0.3);
-    border-radius: 0.5em;
+    border-radius: 0;
 }
 
 footer {
@@ -117,9 +117,9 @@ footer {
     color: #fff;
     text-align: center;
     padding: 0.5em 0;
-    border: 2px solid #0ff;
+    border: 1px solid #333;
     box-shadow: 0 0 10px rgba(0, 255, 255, 0.4);
-    border-radius: 0.5em;
+    border-radius: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -134,7 +134,7 @@ footer {
     float: right;
     background-color: #444;
     color: #fff;
-    border: 2px solid #0ff;
+    border: 1px solid #333;
     box-shadow: 0 0 10px rgba(0, 255, 255, 0.4);
     padding: 0.5em 1em;
     cursor: pointer;
@@ -157,8 +157,8 @@ footer {
     color: #000;
     padding: 1em;
     width: 30vw;
-    border-radius: 0.5em;
-    border: 2px solid #0ff;
+    border-radius: 0;
+    border: 1px solid #333;
     box-shadow: 0 0 20px rgba(0, 255, 255, 0.5);
     z-index: 1001;
 }


### PR DESCRIPTION
## Summary
- modernize page styling
- drop rounded cyan borders for flat grey ones
- update body background gradient
- keep link hover color in line with modern tech aesthetics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684331323478832abca2411b52c64348