### PR TITLE
Improve chat AI icon

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -202,8 +202,9 @@ footer {
 }
 
 .chat-ai-img {
-    width: 120px;
+    width: 140px;
     height: auto;
+    filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.3));
 }
 @media (max-width: 600px) {
     .contact-modal {

--- a/site/index.html
+++ b/site/index.html
@@ -65,7 +65,7 @@ function openPage() {
 }
 </script>
         <section class="chat-ai">
-            <img src="robot.svg" alt="Robot" class="chat-ai-img">
+            <img src="robot.svg" alt="Futuristic robot" class="chat-ai-img">
             <p><a href="https://chat.openai.com/" target="_blank" rel="noopener">Chat with AI</a></p>
         </section>
     </main>

--- a/site/robot.svg
+++ b/site/robot.svg
@@ -1,105 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 128 128" style="enable-background:new 0 0 128 128;" xml:space="preserve">
-<g id="facial_expressions">
-	<g id="robot">
-		<path style="fill:#C62828;" d="M12.53,53.05c-4.57,0.01-8.28,3.72-8.28,8.29v38.38c0.01,4.57,3.71,8.27,8.28,8.28h5.55V53
-			L12.53,53.05z"/>
-		<path style="fill:#C62828;" d="M115.72,53.05c4.57,0.01,8.28,3.72,8.28,8.29v38.38c-0.01,4.57-3.71,8.28-8.28,8.29h-5.55v-55
-			L115.72,53.05z"/>
-		<path style="fill:#90A4AE;" d="M113.17,54.41l-0.12-10c-0.03-4.3-3.53-7.77-7.83-7.75H67.05V23.25c5.11-1.69,7.89-7.2,6.2-12.31
-			c-1.69-5.11-7.2-7.89-12.31-6.2s-7.89,7.2-6.2,12.31c0.97,2.93,3.27,5.24,6.2,6.2v13.46H22.78c-4.28,0.01-7.75,3.47-7.78,7.75
-			v71.78c0.03,4.28,3.5,7.74,7.78,7.76h82.44c4.3,0.01,7.8-3.46,7.83-7.76v-7.37h0.12L113.17,54.41z"/>
-		<path style="fill:#C62828;" d="M64,18c-2.21,0-4-1.79-4-4s1.79-4,4-4c2.21,0,4,1.79,4,4S66.21,18,64,18z"/>
-	</g>
-	<g id="robot-face">
-		<g id="mouth">
-			
-				<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="64.005" y1="22.44" x2="64.005" y2="35.55" gradientTransform="matrix(1 0 0 -1 0 130)">
-				<stop  offset="0.12" style="stop-color:#E0E0E0"/>
-				<stop  offset="0.52" style="stop-color:#FFFFFF"/>
-				<stop  offset="1" style="stop-color:#EAEAEA"/>
-			</linearGradient>
-			<path style="fill:url(#SVGID_1_);" d="M44.15,94.45h39.71c3.46,0,6.27,2.81,6.27,6.27v0.57c0,3.46-2.81,6.27-6.27,6.27H44.15
-				c-3.46,0-6.27-2.81-6.27-6.27v-0.57C37.88,97.26,40.69,94.45,44.15,94.45z"/>
-			
-				<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="54.85" y1="22.44" x2="54.85" y2="35.53" gradientTransform="matrix(1 0 0 -1 0 130)">
-				<stop  offset="0" style="stop-color:#333333"/>
-				<stop  offset="0.55" style="stop-color:#666666"/>
-				<stop  offset="1" style="stop-color:#333333"/>
-			</linearGradient>
-			<rect x="53.67" y="94.47" style="fill:url(#SVGID_2_);" width="2.36" height="13.09"/>
-			
-				<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="64.06" y1="22.44" x2="64.06" y2="35.53" gradientTransform="matrix(1 0 0 -1 0 130)">
-				<stop  offset="0" style="stop-color:#333333"/>
-				<stop  offset="0.55" style="stop-color:#666666"/>
-				<stop  offset="1" style="stop-color:#333333"/>
-			</linearGradient>
-			<rect x="62.88" y="94.47" style="fill:url(#SVGID_3_);" width="2.36" height="13.09"/>
-			
-				<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="73.15" y1="22.44" x2="73.15" y2="35.53" gradientTransform="matrix(1 0 0 -1 0 130)">
-				<stop  offset="0" style="stop-color:#333333"/>
-				<stop  offset="0.55" style="stop-color:#666666"/>
-				<stop  offset="1" style="stop-color:#333333"/>
-			</linearGradient>
-			<rect x="71.97" y="94.47" style="fill:url(#SVGID_4_);" width="2.36" height="13.09"/>
-			
-				<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="82.8" y1="22.44" x2="82.8" y2="35.53" gradientTransform="matrix(1 0 0 -1 0 130)">
-				<stop  offset="0" style="stop-color:#333333"/>
-				<stop  offset="0.55" style="stop-color:#666666"/>
-				<stop  offset="1" style="stop-color:#333333"/>
-			</linearGradient>
-			<rect x="81.62" y="94.47" style="fill:url(#SVGID_5_);" width="2.36" height="13.09"/>
-			
-				<linearGradient id="SVGID_6_" gradientUnits="userSpaceOnUse" x1="45.2" y1="22.46" x2="45.2" y2="35.55" gradientTransform="matrix(1 0 0 -1 0 130)">
-				<stop  offset="0" style="stop-color:#333333"/>
-				<stop  offset="0.55" style="stop-color:#666666"/>
-				<stop  offset="1" style="stop-color:#333333"/>
-			</linearGradient>
-			<rect x="44.02" y="94.45" style="fill:url(#SVGID_6_);" width="2.36" height="13.09"/>
-		</g>
-		<g id="nose">
-			<path style="fill:#C62828;" d="M64,85.33h-5.33c-0.55,0-1-0.45-1-1c0-0.16,0.04-0.31,0.11-0.45l2.74-5.41l2.59-4.78
-				c0.26-0.49,0.87-0.67,1.35-0.41c0.17,0.09,0.31,0.23,0.41,0.41l2.61,5l2.71,5.19c0.25,0.49,0.06,1.09-0.43,1.35
-				c-0.14,0.07-0.29,0.11-0.45,0.11L64,85.33z"/>
-		</g>
-		<g id="eyes">
-			
-				<radialGradient id="SVGID_7_" cx="42.64" cy="63.19" r="11.5" gradientTransform="matrix(1 0 0 -1 0 130)" gradientUnits="userSpaceOnUse">
-				<stop  offset="0.48" style="stop-color:#FFFFFF"/>
-				<stop  offset="0.77" style="stop-color:#FDFDFD"/>
-				<stop  offset="0.88" style="stop-color:#F6F6F6"/>
-				<stop  offset="0.96" style="stop-color:#EBEBEB"/>
-				<stop  offset="1" style="stop-color:#E0E0E0"/>
-			</radialGradient>
-			<circle style="fill:url(#SVGID_7_);" cx="42.64" cy="66.81" r="11.5"/>
-			
-				<linearGradient id="SVGID_8_" gradientUnits="userSpaceOnUse" x1="30.14" y1="63.19" x2="55.14" y2="63.19" gradientTransform="matrix(1 0 0 -1 0 130)">
-				<stop  offset="0" style="stop-color:#333333"/>
-				<stop  offset="0.55" style="stop-color:#666666"/>
-				<stop  offset="1" style="stop-color:#333333"/>
-			</linearGradient>
-			<circle style="fill:none;stroke:url(#SVGID_8_);stroke-width:2;stroke-miterlimit:10;" cx="42.64" cy="66.81" r="11.5"/>
-			
-				<radialGradient id="SVGID_9_" cx="84.95" cy="63.22" r="11.5" gradientTransform="matrix(1 0 0 -1 0 130)" gradientUnits="userSpaceOnUse">
-				<stop  offset="0.48" style="stop-color:#FFFFFF"/>
-				<stop  offset="0.77" style="stop-color:#FDFDFD"/>
-				<stop  offset="0.88" style="stop-color:#F6F6F6"/>
-				<stop  offset="0.96" style="stop-color:#EBEBEB"/>
-				<stop  offset="1" style="stop-color:#E0E0E0"/>
-			</radialGradient>
-			<path style="fill:url(#SVGID_9_);" d="M85,55.28c-6.35,0-11.5,5.15-11.5,11.5s5.15,11.5,11.5,11.5s11.5-5.15,11.5-11.5l0,0
-				C96.49,60.43,91.35,55.29,85,55.28z"/>
-			
-				<linearGradient id="SVGID_10_" gradientUnits="userSpaceOnUse" x1="72.45" y1="63.22" x2="97.45" y2="63.22" gradientTransform="matrix(1 0 0 -1 0 130)">
-				<stop  offset="0" style="stop-color:#333333"/>
-				<stop  offset="0.55" style="stop-color:#666666"/>
-				<stop  offset="1" style="stop-color:#333333"/>
-			</linearGradient>
-			<path style="fill:none;stroke:url(#SVGID_10_);stroke-width:2;stroke-miterlimit:10;" d="M85,55.28c-6.35,0-11.5,5.15-11.5,11.5
-				s5.15,11.5,11.5,11.5s11.5-5.15,11.5-11.5l0,0C96.49,60.43,91.35,55.29,85,55.28z"/>
-		</g>
-	</g>
-</g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bodyGrad" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f4f7fa"/>
+      <stop offset="100%" stop-color="#b0bec5"/>
+    </linearGradient>
+    <linearGradient id="faceGrad" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#e0e0e0"/>
+      <stop offset="100%" stop-color="#90a4ae"/>
+    </linearGradient>
+    <radialGradient id="eyeGrad" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#81d4fa"/>
+      <stop offset="100%" stop-color="#01579b"/>
+    </radialGradient>
+  </defs>
+  <g stroke="#546e7a" stroke-width="2" stroke-linejoin="round">
+    <rect x="20" y="32" width="88" height="76" rx="12" fill="url(#bodyGrad)"/>
+    <rect x="34" y="44" width="60" height="36" rx="8" fill="url(#faceGrad)"/>
+    <circle cx="54" cy="62" r="6" fill="url(#eyeGrad)"/>
+    <circle cx="74" cy="62" r="6" fill="url(#eyeGrad)"/>
+    <path d="M52 78 Q64 86 76 78" fill="none"/>
+    <line x1="64" y1="32" x2="64" y2="20"/>
+    <circle cx="64" cy="16" r="4" fill="#81d4fa" stroke="none"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- redesign robot icon with futuristic style
- enlarge robot icon and add drop shadow
- update alt text for the new robot image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843393f1f58832a9c5e83bdf0e07bc0