### PR TITLE
Add ChatGPT guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ For detailed accessibility guidelines followed by this project, see [ACCESSIBILI
 - Fixed ampersand encoding issues in HTML pages.
 - Moved website files from `site/` into the repository root so the domain loads from `/`.
 - Documentation now lives in the hidden `.docs/` folder for cleaner deployments.
+- Added a new ChatGPT Guide with tips on responsible use.
 
 
 Table of Contents

--- a/chatgpt.html
+++ b/chatgpt.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ChatGPT Guide</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <a href="#maincontent" class="skip-link">Skip to main content</a>
+    <header role="banner">
+        <img src="logo.svg" alt="Ethical AI in Vocational Rehabilitation logo" class="logo">
+        <h1>Using ChatGPT Responsibly</h1>
+    </header>
+    <nav role="navigation" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+    </nav>
+    <main id="maincontent" role="main" tabindex="-1">
+        <h2>Overview</h2>
+        <p>ChatGPT can answer questions about ethical AI and vocational rehabilitation. Remember that its responses are generated from patterns in data and may not always be accurate.</p>
+        <h2>Tips for Effective Use</h2>
+        <ul>
+            <li>Verify important details with trusted sources before acting on them.</li>
+            <li>Provide clear context so the model can give more relevant answers.</li>
+            <li>Be mindful of privacy. Avoid sharing sensitive personal information.</li>
+        </ul>
+        <p><a href="https://chat.openai.com/" target="_blank" rel="noopener">Launch ChatGPT in a new window</a></p>
+    </main>
+    <footer role="contentinfo">
+        <p>&copy; 2023 Ethical AI in Vocational Rehabilitation</p>
+        <button id="contactBtn" class="contact-btn">Contact Us</button>
+    </footer>
+    <div id="modalOverlay" class="modal-overlay" hidden></div>
+    <div id="contactModal" class="contact-modal" role="dialog" aria-labelledby="contactTitle" hidden>
+        <button id="closeModal" class="close-btn" aria-label="Close Contact Form">&times;</button>
+        <h2 id="contactTitle">Contact Us</h2>
+        <p>Billy Belz</p>
+        <p>Phone: 214-912-0619</p>
+        <p>Email: Billy@vra11y.com</p>
+        <p>Discord: #ethical-ai</p>
+    </div>
+    <script src="js/modal.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <a href="technical.html">Technical Guidance</a>
         <a href="community.html">Community</a>
         <a href="ethical-ai-documentation.html">AI Documentation</a>
+        <a href="chatgpt.html">ChatGPT Guide</a>
     </nav>
     <main id="maincontent" role="main" tabindex="-1">
         <section class="hero">
@@ -48,6 +49,7 @@
     <option data-href="technical.html" value="Technical Guidance"></option>
     <option data-href="community.html" value="Community"></option>
     <option data-href="ethical-ai-documentation.html" value="AI Documentation"></option>
+    <option data-href="chatgpt.html" value="ChatGPT Guide"></option>
   </datalist>
   <button type="submit">Go</button>
 </form>
@@ -67,6 +69,7 @@ function openPage() {
         <section class="chat-ai">
             <img src="robot.svg" alt="Futuristic robot" class="chat-ai-img">
             <p><a href="https://chat.openai.com/" target="_blank" rel="noopener">Chat with AI</a></p>
+            <p><a href="chatgpt.html">Read our ChatGPT Guide</a></p>
         </section>
     </main>
     <footer role="contentinfo">


### PR DESCRIPTION
## Summary
- add ChatGPT Guide page describing responsible use
- link the new guide from the nav bar and search list
- reference the guide in the README

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684786e837ac832a82b7fba0be28d6bd