### PR TITLE
Add Google Gemini guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For detailed accessibility guidelines followed by this project, see [ACCESSIBILI
 - Moved website files from `site/` into the repository root so the domain loads from `/`.
 - Documentation now lives in the hidden `.docs/` folder for cleaner deployments.
 - Added a new ChatGPT Guide with tips on responsible use.
+- Introduced a Google Gemini Guide describing how states are leveraging Gemini models as a preferred AI vendor.
 
 
 Table of Contents

--- a/gemini.html
+++ b/gemini.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Google Gemini Guide</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <a href="#maincontent" class="skip-link">Skip to main content</a>
+    <header role="banner">
+        <img src="logo.svg" alt="Ethical AI in Vocational Rehabilitation logo" class="logo">
+        <h1>Using Google Gemini Models</h1>
+    </header>
+    <nav role="navigation" aria-label="Main navigation">
+        <a href="index.html">Home</a>
+    </nav>
+    <main id="maincontent" role="main" tabindex="-1">
+        <h2>Overview</h2>
+        <p>Google's Gemini models provide state-of-the-art generative text capabilities. Several state vocational rehabilitation programs now use Gemini as their preferred vendor for summarizing case notes and drafting client communications.</p>
+        <h2>Implementation Tips</h2>
+        <ul>
+            <li>Check your state's procurement and data privacy requirements before adopting Gemini services.</li>
+            <li>Maintain logs of prompts and outputs so staff can audit how the model was used.</li>
+            <li>Keep human reviewers in the loop to ensure generated text aligns with VR policies.</li>
+        </ul>
+        <p><a href="https://gemini.google.com" target="_blank" rel="noopener">Explore Gemini models</a></p>
+    </main>
+    <footer role="contentinfo">
+        <p>&copy; 2023 Ethical AI in Vocational Rehabilitation</p>
+        <button id="contactBtn" class="contact-btn">Contact Us</button>
+    </footer>
+    <div id="modalOverlay" class="modal-overlay" hidden></div>
+    <div id="contactModal" class="contact-modal" role="dialog" aria-labelledby="contactTitle" hidden>
+        <button id="closeModal" class="close-btn" aria-label="Close Contact Form">&times;</button>
+        <h2 id="contactTitle">Contact Us</h2>
+        <p>Billy Belz</p>
+        <p>Phone: 214-912-0619</p>
+        <p>Email: Billy@vra11y.com</p>
+        <p>Discord: #ethical-ai</p>
+    </div>
+    <script src="js/modal.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <a href="community.html">Community</a>
         <a href="ethical-ai-documentation.html">AI Documentation</a>
         <a href="chatgpt.html">ChatGPT Guide</a>
+        <a href="gemini.html">Google Gemini Guide</a>
     </nav>
     <main id="maincontent" role="main" tabindex="-1">
         <section class="hero">
@@ -50,6 +51,7 @@
     <option data-href="community.html" value="Community"></option>
     <option data-href="ethical-ai-documentation.html" value="AI Documentation"></option>
     <option data-href="chatgpt.html" value="ChatGPT Guide"></option>
+    <option data-href="gemini.html" value="Google Gemini Guide"></option>
   </datalist>
   <button type="submit">Go</button>
 </form>
@@ -70,6 +72,7 @@ function openPage() {
             <img src="robot.svg" alt="Futuristic robot" class="chat-ai-img">
             <p><a href="https://chat.openai.com/" target="_blank" rel="noopener">Chat with AI</a></p>
             <p><a href="chatgpt.html">Read our ChatGPT Guide</a></p>
+            <p><a href="gemini.html">Read our Google Gemini Guide</a></p>
         </section>
     </main>
     <footer role="contentinfo">


### PR DESCRIPTION
## Summary
- introduce a short guide explaining how states can use Google Gemini
- link the Gemini guide from the home page navigation, search suggestions, and chat AI section
- note the new page in the README

## Testing
- `tidy -q -errors gemini.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa6e83424832aa1df8c30121b547b